### PR TITLE
Don't violate C aliasing rules in the CR/LF check

### DIFF
--- a/src/line.c
+++ b/src/line.c
@@ -57,7 +57,7 @@ bool        get_next_line(t_line *dst, t_chunk *chunk)
             size -= 1;
             chunk->ptr += 1;
         }
-        else if (size > 1 && *(uint16_t*)chunk->ptr == *(uint16_t*)"\r\n")
+        else if (chunk->ptr[0] == '\r' && size > 1 && chunk->ptr[1] == '\n')
         {
             size -= 2;
             chunk->ptr += 2;


### PR DESCRIPTION
This line violated C aliasing rules. Being UB, the compiler was free to drop this check and its following block of code as an optimization, or do anything else it might have liked to do.

I think my changed code might also be (very slightly) faster due to short-circuit evaluation: in the original, `size > 1` was likely true, so the second check was frequently reached, whereas in my alternative the very first check is likely to be `false`, so the remaining 2 checks are rarely reached.

Please test this with an actual CR/LF line. I did not.