### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -48,7 +48,7 @@ void            error(const char *fmt, ...)
 
 /** Suddenly exit the program with fatal error.
  * Unlike error(), this function does not allocates
- * any additionnal memory before exiting program.
+ * any additional memory before exiting program.
  */
 void            die(const char *msg)
 {

--- a/src/file.c
+++ b/src/file.c
@@ -55,7 +55,7 @@ static void close_file(struct file *file)
 }
 
 
-/** Destructor callback for optentially open files
+/** Destructor callback for potentially open files
  * Close infile, outfile and tmpfile (if exists)
  */
 static void close_all(void)
@@ -87,7 +87,7 @@ static void open_file(struct file *file, const char *pathname, int flags)
 
 
 /** Specific opener for g_tmpfile, which also uses mkstemp.
- * This function is a singleton (sould be called once).
+ * This function is a singleton (should be called once).
  */
 static void create_tmpfile(void)
 {
@@ -173,7 +173,7 @@ static void copy_file(int dst_fd, int src_fd, bool send_status)
  * - Handle src/dst files, and return a struct file* for use by duplicut.
  * - Can deal with non-regular files
  * - Registers cleanup functions with atexit()
- * - returned file has `addr` attribute mapped in memoy
+ * - returned file has `addr` attribute mapped in memory
  */
 void        init_file(const char *infile_name, const char *outfile_name)
 {

--- a/src/hmap.c
+++ b/src/hmap.c
@@ -37,7 +37,7 @@ void        destroy_hmap(void)
 }
 
 
-/** Populate `hmap` whith given `chunk` lines.
+/** Populate `hmap` with given `chunk` lines.
  * - Handle collisions & disable duplicate lines from `chunk`
  *   by tagging them with 'DISABLED_LINE'.
  * - Unique lines are normally written into `hmap`.

--- a/src/memstate.c
+++ b/src/memstate.c
@@ -37,7 +37,7 @@ static long long    get_mem_available(void)
 
 /** Update current memory state.
  * Unlike `init_memstate()`, this function only refreshes
- * ther values that may have changed.
+ * their values that may have changed.
  * For example, it does not changes `page_size`, which
  * is a static value.
  */

--- a/src/optparse.c
+++ b/src/optparse.c
@@ -12,7 +12,7 @@
 #include "debug.h"
 
 
-/** Arguments cofiguration for getopt_long().
+/** Arguments configuration for getopt_long().
  */
 #define OPTSTRING "o:t:m:l:pcChv"
 
@@ -221,7 +221,7 @@ static void setopt(int opt, const char *value)
 /** Set options by filling out g_conf globale.
  * It first uses setopt() in order to set option arguments,
  * then handles main argument (input file) separately,
- * throught setopt_input().
+ * through setopt_input().
  */
 void        optparse(int argc, char **argv)
 {

--- a/src/thpool.c
+++ b/src/thpool.c
@@ -205,7 +205,7 @@ void thpool_wait(thpool_* thpool_p){
 
 /* Destroy the threadpool */
 void thpool_destroy(thpool_* thpool_p){
-	/* No need to destory if it's NULL */
+	/* No need to destroy if it's NULL */
 	if (thpool_p == NULL) return ;
 
 	volatile int threads_total = thpool_p->num_threads_alive;
@@ -254,7 +254,7 @@ void thpool_pause(thpool_* thpool_p) {
 /* Resume all threads in threadpool */
 void thpool_resume(thpool_* thpool_p) {
     // resuming a single threadpool hasn't been
-    // implemented yet, meanwhile this supresses
+    // implemented yet, meanwhile this suppresses
     // the warnings
     (void)thpool_p;
 
@@ -308,7 +308,7 @@ static void thread_hold(int sig_id) {
 
 /* What each thread is doing
 *
-* In principle this is an endless loop. The only time this loop gets interuppted is once
+* In principle this is an endless loop. The only time this loop gets interrupted is once
 * thpool_destroy() is invoked or the program exits.
 *
 * @param  thread        thread that will run this function
@@ -316,7 +316,7 @@ static void thread_hold(int sig_id) {
 */
 static void* thread_do(struct thread* thread_p){
 
-	/* Set thread name for profiling and debuging */
+	/* Set thread name for profiling and debugging */
 	char thread_name[128] = {0};
 	sprintf(thread_name, "thread-pool-%d", thread_p->id);
 

--- a/test/scripts/remove-duplicates.py
+++ b/test/scripts/remove-duplicates.py
@@ -39,7 +39,7 @@ if LOWERCASE:
 elif UPPERCASE:
     content = content.upper()
 
-# use re.split(), because str.spllitlines() assumes
+# use re.split(), because str.splitlines() assumes
 # that single "\r" are newline chars too..
 lines = re.split(b"\r\n|\n", content)
 


### PR DESCRIPTION
There are small typos in:
- src/error.c
- src/file.c
- src/hmap.c
- src/memstate.c
- src/optparse.c
- src/thpool.c
- test/scripts/remove-duplicates.py

Fixes:
- Should read `with` rather than `whith`.
- Should read `through` rather than `throught`.
- Should read `their` rather than `ther`.
- Should read `suppresses` rather than `supresses`.
- Should read `splitlines` rather than `spllitlines`.
- Should read `potentially` rather than `optentially`.
- Should read `memory` rather than `memoy`.
- Should read `interrupted` rather than `interuppted`.
- Should read `destroy` rather than `destory`.
- Should read `debugging` rather than `debuging`.
- Should read `should` rather than `sould`.
- Should read `configuration` rather than `cofiguration`.
- Should read `additional` rather than `additionnal`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md